### PR TITLE
Fix autoscroll position

### DIFF
--- a/src/db/DbGame.ts
+++ b/src/db/DbGame.ts
@@ -34,6 +34,7 @@ export const useDbGameLogs = async (roomId?: string) => {
     return onChildAdded(logsRef, (log) => {
       console.debug(log.key, log.val());
       gameActionBuffer.push(log.val());
+      flushBuffer();
       clearTimeout(flushBufferTimer);
       flushBufferTimer = setTimeout(flushBuffer, 0);
     });

--- a/src/db/DbGame.ts
+++ b/src/db/DbGame.ts
@@ -34,7 +34,6 @@ export const useDbGameLogs = async (roomId?: string) => {
     return onChildAdded(logsRef, (log) => {
       console.debug(log.key, log.val());
       gameActionBuffer.push(log.val());
-      flushBuffer();
       clearTimeout(flushBufferTimer);
       flushBufferTimer = setTimeout(flushBuffer, 0);
     });

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -67,7 +67,7 @@ interface RollAnimation {
   kind: "roll";
   playerId: string;
   dice: [number, number];
-  destination: number;
+  destinationId: string;
   direction: "up" | "down";
   steps: number[];
 }
@@ -339,7 +339,7 @@ export const roll = (
         kind: "roll",
         playerId: player.id,
         dice: [die1, die2],
-        destination: dest,
+        destinationId: dest === -1 ? "submarine" : state.path[dest].id,
         direction,
         steps,
       },


### PR DESCRIPTION
Use space id instead of index to store space refs
so that we can look them up consistently in latter
rounds when the path has been collapsed.
